### PR TITLE
feat: Implement Fleet Manager with IndexedDB persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,28 +10,35 @@ function Airline() {
   return <h2>Airline</h2>;
 }
 
+const dbName = 'msfs-career';
+const dbVersion = 1;
+const paywareStoreName = 'payware-airports';
+const fleetStoreName = 'fleet';
+
+// --- Database Helper ---
+async function openDb() {
+  return idb.openDB(dbName, dbVersion, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(paywareStoreName)) {
+        db.createObjectStore(paywareStoreName, { keyPath: 'icao' });
+      }
+      if (!db.objectStoreNames.contains(fleetStoreName)) {
+        db.createObjectStore(fleetStoreName, { keyPath: 'reg' });
+      }
+    },
+  });
+}
+
+
 function Payware() {
   const [airports, setAirports] = useState([]);
   const [formState, setFormState] = useState({ icao: '', city: '', country: '', continent: '' });
-  const dbName = 'msfs-career';
-  const storeName = 'payware-airports';
-
-  // Function to open the database
-  async function openDb() {
-    return idb.openDB(dbName, 1, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains(storeName)) {
-          db.createObjectStore(storeName, { keyPath: 'icao' });
-        }
-      },
-    });
-  }
 
   // Load airports from DB on component mount
   useEffect(() => {
     async function loadAirports() {
       const db = await openDb();
-      const allAirports = await db.getAll(storeName);
+      const allAirports = await db.getAll(paywareStoreName);
       setAirports(allAirports);
     }
     loadAirports();
@@ -46,7 +53,7 @@ function Payware() {
     e.preventDefault();
     if (formState.icao && formState.city && formState.country && formState.continent) {
       const db = await openDb();
-      await db.put(storeName, formState);
+      await db.put(paywareStoreName, formState);
       setAirports([...airports, formState]);
       setFormState({ icao: '', city: '', country: '', continent: '' }); // Reset form
     }
@@ -54,7 +61,7 @@ function Payware() {
 
   const handleDeleteAirport = async (icaoToDelete) => {
     const db = await openDb();
-    await db.delete(storeName, icaoToDelete);
+    await db.delete(paywareStoreName, icaoToDelete);
     setAirports(airports.filter(airport => airport.icao !== icaoToDelete));
   };
 
@@ -97,7 +104,79 @@ function Payware() {
 }
 
 function Fleet() {
-  return <h2>Fleet</h2>;
+  const [fleet, setFleet] = useState([]);
+  const [formState, setFormState] = useState({ reg: '', type: '', homeBase: '', status: 'active' });
+
+  useEffect(() => {
+    async function loadFleet() {
+      const db = await openDb();
+      const allFleet = await db.getAll(fleetStoreName);
+      setFleet(allFleet);
+    }
+    loadFleet();
+  }, []);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    const val = name === 'reg' || name === 'homeBase' ? value.toUpperCase() : value;
+    setFormState(prevState => ({ ...prevState, [name]: val }));
+  };
+
+  const handleAddAircraft = async (e) => {
+    e.preventDefault();
+    if (formState.reg && formState.type && formState.homeBase) {
+      const db = await openDb();
+      await db.put(fleetStoreName, formState);
+      setFleet([...fleet, formState]);
+      setFormState({ reg: '', type: '', homeBase: '', status: 'active' }); // Reset form
+    }
+  };
+
+  const handleDeleteAircraft = async (regToDelete) => {
+    const db = await openDb();
+    await db.delete(fleetStoreName, regToDelete);
+    setFleet(fleet.filter(ac => ac.reg !== regToDelete));
+  };
+
+  return (
+    <div>
+      <h2>Fleet Manager</h2>
+      <form onSubmit={handleAddAircraft} style={{ marginBottom: '1rem' }}>
+        <input name="reg" value={formState.reg} onChange={handleInputChange} placeholder="Registration" required style={{ marginRight: '8px' }} />
+        <input name="type" value={formState.type} onChange={handleInputChange} placeholder="Aircraft Type" required style={{ marginRight: '8px' }} />
+        <input name="homeBase" value={formState.homeBase} onChange={handleInputChange} placeholder="Home Base (ICAO)" maxLength="4" required style={{ marginRight: '8px' }} />
+        <select name="status" value={formState.status} onChange={handleInputChange} style={{ marginRight: '8px' }}>
+            <option value="active">Active</option>
+            <option value="mx">Maintenance</option>
+        </select>
+        <button type="submit">Add Aircraft</button>
+      </form>
+      <table>
+        <thead>
+          <tr>
+            <th>Registration</th>
+            <th>Type</th>
+            <th>Home Base</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {fleet.map(ac => (
+            <tr key={ac.reg}>
+              <td>{ac.reg}</td>
+              <td>{ac.type}</td>
+              <td>{ac.homeBase}</td>
+              <td>{ac.status}</td>
+              <td>
+                <button onClick={() => handleDeleteAircraft(ac.reg)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 function Rules() {


### PR DESCRIPTION
This commit builds upon the vanilla JS proof-of-concept by adding a functional Fleet Manager page.

Key features:
- A UI for adding, viewing, and deleting aircraft from the fleet.
- An `openDb` helper function has been created to provide a reusable and extensible way to manage IndexedDB object stores.
- The Fleet Manager's data is now persisted to IndexedDB, similar to the Payware Airports feature.
- The Payware Airports component has been refactored to use the new `openDb` helper.