### PR TITLE
fix: Correct database versioning for Fleet store

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ function Airline() {
 }
 
 const dbName = 'msfs-career';
-const dbVersion = 1;
+const dbVersion = 2;
 const paywareStoreName = 'payware-airports';
 const fleetStoreName = 'fleet';
 


### PR DESCRIPTION
This commit fixes a bug where the Fleet Manager page was not functional for existing users.

The issue was caused by the database version not being incremented when the new 'fleet' object store was added. This prevented the `upgrade` callback in `idb.openDB` from running, so the new store was never created for users who already had the database from a previous version.

The database version has been incremented from 1 to 2, which will now correctly trigger the creation of the 'fleet' object store.