### PR TITLE
chore: Add alert to debug idb library loading

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,6 +129,8 @@ function Fleet() {
       await db.put(fleetStoreName, formState);
       setFleet([...fleet, formState]);
       setFormState({ reg: '', type: '', homeBase: '', status: 'active' }); // Reset form
+    } else {
+      alert('Please fill out all required fields: Registration, Type, and Home Base.');
     }
   };
 
@@ -192,6 +194,12 @@ function Schedule() {
 
 function App() {
   const [route, setRoute] = useState('dashboard');
+
+  useEffect(() => {
+    if (!window.idb) {
+      alert("Error: The database library (idb) failed to load. The application will not be able to save data.");
+    }
+  }, []);
 
   const navigateTo = (page) => {
     setRoute(page);


### PR DESCRIPTION
This commit adds a debugging alert to the main App component. The alert checks for the presence of the `window.idb` object on application load.

This is intended to diagnose a bug where both the Payware and Fleet manager pages are not functional. The hypothesis is that the `idb` library is failing to load from the CDN, which would cause all database operations to fail.