### PR TITLE
fix: Correct idb library CDN URL and remove debug alert

### DIFF
--- a/app.js
+++ b/app.js
@@ -195,12 +195,6 @@ function Schedule() {
 function App() {
   const [route, setRoute] = useState('dashboard');
 
-  useEffect(() => {
-    if (!window.idb) {
-      alert("Error: The database library (idb) failed to load. The application will not be able to save data.");
-    }
-  }, []);
-
   const navigateTo = (page) => {
     setRoute(page);
   };

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script src="https://unpkg.com/idb/build/iife/index.js"></script>
+  <script src="https://unpkg.com/idb/build/umd.js"></script>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
This commit resolves the critical bug that was preventing all database operations from working.

The root cause was an incorrect CDN URL for the `idb` library, which resulted in the library not loading and the `window.idb` object being undefined.

This fix involves:
1.  Updating the `<script>` tag in `index.html` to point to the correct UMD build of the `idb` library on unpkg.com.
2.  Removing the temporary debugging alert that was added to diagnose the issue.

With this change, both the Payware and Fleet manager pages should now be fully functional.